### PR TITLE
Removing suffix and zip

### DIFF
--- a/mammoth-verbose.py
+++ b/mammoth-verbose.py
@@ -424,6 +424,5 @@ output.write(html)
 output.close()
 
 # cleanup
-print(newZipName)
 os.remove(newZipName)
 shutil.rmtree(filePath)


### PR DESCRIPTION
Removing the modified class name suffix from the HTML and deleting the temp zip file we created.

Fixes #6  and fixes #7 